### PR TITLE
Handle Redis connection failure in loop

### DIFF
--- a/tests/test_cli_redis_connection.py
+++ b/tests/test_cli_redis_connection.py
@@ -1,0 +1,24 @@
+import sys
+import types
+import redis
+from click.testing import CliRunner
+
+
+def test_loop_exits_when_redis_unavailable(monkeypatch):
+    fake_arch = types.ModuleType("arch")
+    fake_arch.arch_model = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "arch", fake_arch)
+
+    def boom(self):
+        raise redis.exceptions.ConnectionError("mock")
+
+    monkeypatch.setattr(redis.Redis, "ping", boom)
+
+    from v26meme.cli import loop
+
+    runner = CliRunner()
+    result = runner.invoke(loop)
+
+    assert result.exit_code == 1
+    assert "start redis-server" in result.output.lower()
+

--- a/v26meme/cli.py
+++ b/v26meme/cli.py
@@ -12,6 +12,7 @@ from loguru import logger
 import pandas as pd
 import numpy as np
 import glob as _glob  # added for retro coverage reindex
+import redis
 
 from v26meme.core.state import StateManager
 from v26meme.core.config import RootConfig
@@ -498,7 +499,14 @@ def loop() -> None:
     if ((cfg.get("llm") or {}).get("provider", "").lower() != "openai" or not os.getenv("OPENAI_API_KEY", "")):
         logger.warning("LLM is OpenAI-only. Set llm.provider=openai and OPENAI_API_KEY in .env.")
 
-    state = StateManager(cfg["system"]["redis_host"], cfg["system"]["redis_port"])
+    host, port = cfg["system"]["redis_host"], cfg["system"]["redis_port"]
+    try:
+        state = StateManager(host, port)
+    except redis.exceptions.ConnectionError:
+        logger.critical(
+            f"FATAL: Redis unavailable at {host}:{port}. Start redis-server and retry."
+        )
+        raise SystemExit(1)
     
     # Check for persistent risk halt on startup
     if state.get("risk:halt"):


### PR DESCRIPTION
## Summary
- guard loop startup against missing Redis
- add regression test for Redis unavailability

## Testing
- `pytest tests/test_cli_redis_connection.py -q`
- `pytest -q` *(fails: No module named 'arch')*

------
https://chatgpt.com/codex/tasks/task_e_68aea12194ac832ca6cfd6db8ffeadfa